### PR TITLE
Optionally: don't override solr entries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,17 @@ Configure your settings.py:
       'price': 'price',
       'title': 'title'
     }
+    SOLR_IGNORE_DUPLICATES = True
+    SOLR_DUPLICATES_KEY_FIELDS = ['id']
 
 The SOLR_MAPPING setting, maps your item's fields to Solr fields. Usually some transformations will be needed e.g. a url might be used as Solr id. You can use multiple Scrapy fields for a single Solr field as you can see in the 'text' mapping above. The 'text' happens to be the default field for the default Solr schema and as a result you can use it to simplify your queries (since you don't have to include the field if you want to match everything).
+SOLR_IGNORE_DUPLICATES and SOLR_DUPLICATES_KEY_FIELDS, the id keys to search for an existing entry, are used to only insert into Solr if the item is not already there. The key fields have to be defined as sources in the mapping.
 
 Changelog
 =========
+
+0.2.0
+Ability to not override a Solr entry when the item is already present.
 
 0.1.0
 initial release

--- a/scrapysolr.py
+++ b/scrapysolr.py
@@ -15,6 +15,7 @@
 """Solr Pipeline for scrapy"""
 
 import pysolr
+import logging
 from scrapy.conf import settings
 
 
@@ -27,28 +28,26 @@ class SolrPipeline(object):
             raise RuntimeError('To ignore duplicates SOLR_DUPLICATES_KEY_FIELDS has to be defined')
         self.solr = pysolr.Solr(settings['SOLR_URL'], timeout=10)
 
+    def process_item(self, item, spider):
+        if self.ignore_duplicates:
+            dup_keys_values = [str(dst) + ':' + '"' + self.__get_item_value__(item, src) + '"' for dst, src in
+                               self.mapping
+                               if dst in self.id_fields]
+            query = " ".join(dup_keys_values)
+            result = self.solr.search(query)
+            if len(result) != 0:
+                logging.info('Skipping duplicate')
+                return item
+        solr_item = {}
+        for dst, src in self.mapping:
+            solr_item[dst] = self.__get_item_value__(item, src)
+        self.solr.add([solr_item])
+        return item
 
-def process_item(self, item, spider):
-    if self.ignore_duplicates:
-        dup_keys_values = [str(dst) + ':' + '"' + self.__get_item_value__(item, src) + '"' for dst, src in
-                           self.mapping
-                           if dst in self.id_fields]
-        query = " ".join(dup_keys_values)
-        result = self.solr.search(query)
-        if len(result) != 0:
-            logging.info('Skipping duplicate')
-            return item
-    solr_item = {}
-    for dst, src in self.mapping:
-        solr_item[dst] = self.__get_item_value__(item, src)
-    self.solr.add([solr_item])
-    return item
-
-
-def __get_item_value__(self, item, src):
-    if type(src) is str:
-        return item[src] if src in item else None
-    elif type(src) is list:
-        return [item[i] if i in item else None for i in src]
-    else:
-        raise TypeError('Only string and list are valid mapping source')
+    def __get_item_value__(self, item, src):
+        if type(src) is str:
+            return item[src] if src in item else None
+        elif type(src) is list:
+            return [item[i] if i in item else None for i in src]
+        else:
+            raise TypeError('Only string and list are valid mapping source')

--- a/scrapysolr.py
+++ b/scrapysolr.py
@@ -17,21 +17,38 @@
 import pysolr
 from scrapy.conf import settings
 
-class SolrPipeline(object):
 
+class SolrPipeline(object):
     def __init__(self):
         self.mapping = settings['SOLR_MAPPING'].items()
+        self.ignore_duplicates = settings['SOLR_IGNORE_DUPLICATES'] or False
+        self.id_fields = settings['SOLR_DUPLICATES_KEY_FIELDS']
+        if self.ignore_duplicates and not self.id_fields:
+            raise RuntimeError('To ignore duplicates SOLR_DUPLICATES_KEY_FIELDS has to be defined')
         self.solr = pysolr.Solr(settings['SOLR_URL'], timeout=10)
 
-    def process_item(self, item, spider):
-        solr_item = {}
-        for dst, src in self.mapping:
-            if type(src) is str:
-                solr_item[dst] = item[src] if src in item else None
-            elif type(src) is list:
-                solr_item[dst] = [item[i] if i in item else None for i in src]
-            else:
-                assert False
-                
-        self.solr.add([solr_item])
-        return item
+
+def process_item(self, item, spider):
+    if self.ignore_duplicates:
+        dup_keys_values = [str(dst) + ':' + '"' + self.__get_item_value__(item, src) + '"' for dst, src in
+                           self.mapping
+                           if dst in self.id_fields]
+        query = " ".join(dup_keys_values)
+        result = self.solr.search(query)
+        if len(result) != 0:
+            logging.info('Skipping duplicate')
+            return item
+    solr_item = {}
+    for dst, src in self.mapping:
+        solr_item[dst] = self.__get_item_value__(item, src)
+    self.solr.add([solr_item])
+    return item
+
+
+def __get_item_value__(self, item, src):
+    if type(src) is str:
+        return item[src] if src in item else None
+    elif type(src) is list:
+        return [item[i] if i in item else None for i in src]
+    else:
+        raise TypeError('Only string and list are valid mapping source')

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 setup(name='scrapysolr',
-      version='0.1.0',
+      version='0.2.0',
       license='Apache License, Version 2.0',
       description='Scrapy pipeline which allows you to store scrapy items in a Solr server.',
       author='Dimitrios Kouzis-Loukas',


### PR DESCRIPTION
This may be useful for crawls where you don't want to override entries.
In some use cases, solr documents may be changed after a crawl and we don't want a re crawl to override those changes.
In my case I'm using other pipelines processes to categorise a crawled document. That may change if the automatic categorisation is not right. It is not practical to store that in other places. There are also other things that may change. 

This change is backward compatible (that's why the version is 0.2.0). If the new config fileds are not present, then this behaves exactly the same as version 0.1.0. 
